### PR TITLE
Feature/delete outfit card

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,13 +255,8 @@ function undressBear() {
   }
 }
 
-//the card needs to be removed from two places: the array, and the DOM
-//we need to figure out which card was clicked on -- event bubbling
-//we need to splice it from the array
-//resend it to local storage
-
 function removeOutfitCard(event) {
-  // console.log(event);
+
   for (var i = 0; i < allOutfitCards.length; i++) {
     if (event.target.dataset.id === allOutfitCards[i].id) {
       allOutfitCards.splice(i, 1);
@@ -269,6 +264,7 @@ function removeOutfitCard(event) {
     }
   }
 
-  console.log(allOutfitCards);
+  var updatedStringifiedOutfitCards = JSON.stringify(allOutfitCards);
+  localStorage.setItem("savedOutfit", updatedStringifiedOutfitCards);
 
 }

--- a/main.js
+++ b/main.js
@@ -262,11 +262,10 @@ function undressBear() {
 
 function removeOutfitCard(event) {
   // console.log(event);
-
-
   for (var i = 0; i < allOutfitCards.length; i++) {
     if (event.target.dataset.id === allOutfitCards[i].id) {
       allOutfitCards.splice(i, 1);
+      event.target.parentElement.parentElement.remove();
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ var clothesContainer = document.querySelector('.clothes');
 var backgroundImages = document.querySelectorAll('.background-img');
 var backgroundsContainer = document.querySelector('.backgrounds');
 var titleInput = document.querySelector('input');
+var savedOutfitsContainer = document.querySelector('.saved-outfits-container');
 var allOutfitCards;
 
 
@@ -27,6 +28,7 @@ clothesContainer.addEventListener('click', toggleClothes);
 backgroundsContainer.addEventListener('click', clickedBackgroundsButtons);
 backgroundsContainer.addEventListener('click', toggleBackgrounds);
 titleInput.addEventListener('input', toggleSaveBtn);
+savedOutfitsContainer.addEventListener('click', removeOutfitCard);
 
 function createNewOutfitInstance() {
   allOutfitCards = [];
@@ -57,11 +59,10 @@ function clearBackgroundAndGarments() {
 }
 
 function createSavedOutfitCard(outfitInfo) {
-  var savedOutfitsContainer = document.querySelector('.saved-outfits-container');
   savedOutfitsContainer.innerHTML +=
     `<div>
       <p>${outfitInfo.title}</p>
-      <button id=${outfitInfo.id}type="button" name="button"><img src="./assets/cancel.svg" alt="close icon"></button>
+      <button id="${outfitInfo.id}" type="button" name="button"><img data-id="${outfitInfo.id}" src="./assets/cancel.svg" alt="close icon"></button>
     </div>`
   clearBackgroundAndGarments()
   saveButton.disabled = true;
@@ -252,4 +253,23 @@ function undressBear() {
   for (var i = 1; i < 15; i++) {
     allImages[i].classList.add('hidden');
   }
+}
+
+//the card needs to be removed from two places: the array, and the DOM
+//we need to figure out which card was clicked on -- event bubbling
+//we need to splice it from the array
+//resend it to local storage
+
+function removeOutfitCard(event) {
+  // console.log(event);
+
+
+  for (var i = 0; i < allOutfitCards.length; i++) {
+    if (event.target.dataset.id === allOutfitCards[i].id) {
+      allOutfitCards.splice(i, 1);
+    }
+  }
+
+  console.log(allOutfitCards);
+
 }


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Detailed Description
We added a function to remove an outfit card from the allOutfitCards array and remove it from the DOM. Once an outfit card is removed from those two places, it is also removed from local storage via updating the local storage key with the new data.

### Why is this change required? What problem does it solve?
This functionality is needed for a user to be able to delete outfit cards as desired and have them remain deleted upon page refresh/load.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Figuring out how to target and match the delete button that was clicked on and match it to something that would allow us to accurately delete what was clicked on.

### Files modified:
- [ ] index.html
- [ ] styles.css
- [X] main.js
- [ ] Other files:
